### PR TITLE
Fix/find and lock next job query

### DIFF
--- a/lib/agenda/find-and-lock-next-job.ts
+++ b/lib/agenda/find-and-lock-next-job.ts
@@ -59,7 +59,7 @@ export const findAndLockNextJob = async function (
           name: jobName,
           disabled: { $ne: true },
           lockedAt: { $eq: null },
-          nextRunAt: { $lte: this._nextScanAt },
+          nextRunAt: { $lte: new Date() },
         },
         {
           name: jobName,

--- a/lib/agenda/find-and-lock-next-job.ts
+++ b/lib/agenda/find-and-lock-next-job.ts
@@ -54,21 +54,17 @@ export const findAndLockNextJob = async function (
     // * @type {{$and: [*]}}
     // */
     const JOB_PROCESS_WHERE_QUERY = {
-      $and: [
+      $or: [
         {
           name: jobName,
           disabled: { $ne: true },
+          lockedAt: { $eq: null },
+          nextRunAt: { $lte: this._nextScanAt },
         },
         {
-          $or: [
-            {
-              lockedAt: { $eq: null },
-              nextRunAt: { $lte: this._nextScanAt },
-            },
-            {
-              lockedAt: { $lte: lockDeadline },
-            },
-          ],
+          name: jobName,
+          disabled: { $ne: true },
+          lockedAt: { $lte: lockDeadline },
         },
       ],
     };

--- a/lib/agenda/find-and-lock-next-job.ts
+++ b/lib/agenda/find-and-lock-next-job.ts
@@ -79,7 +79,7 @@ export const findAndLockNextJob = async function (
      * Query used to affect what gets returned
      * @type {{returnOriginal: boolean, sort: object}}
      */
-    const JOB_RETURN_QUERY = { returnOriginal: false, sort: this._sort };
+    const JOB_RETURN_QUERY = { returnOriginal: false };
 
     // Find ONE and ONLY ONE job and set the 'lockedAt' time so that job begins to be processed
     const result = await this._collection.findOneAndUpdate(

--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
   "description": "Light weight job scheduler for Node.js",
   "main": "index.js",
   "files": [
-    "dist"
+    "lib",
+    "tsconfig.json"
   ],
   "engines": {
     "node": ">=10.0.0"
   },
   "scripts": {
     "prepublishOnly": "npm run build",
+    "postinstall": "npm run build",
     "build": "tsc",
     "pretest": "npm run build",
     "test": "npm run mocha",
@@ -51,12 +53,13 @@
     "debug": "~4.3.0",
     "human-interval": "~2.0.0",
     "moment-timezone": "~0.5.27",
-    "mongodb": "~3.6.2"
-  },
-  "devDependencies": {
+    "mongodb": "~3.6.2",
+    "typescript": "4.1.3",
     "@types/debug": "4.1.5",
     "@types/human-interval": "1.0.0",
-    "@types/mongodb": "3.6.3",
+    "@types/mongodb": "3.6.3"
+  },
+  "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
     "blanket": "1.2.3",
@@ -73,8 +76,7 @@
     "mocha-lcov-reporter": "1.3.0",
     "prettier": "^2.2.1",
     "q": "1.5.1",
-    "sinon": "9.2.4",
-    "typescript": "4.1.3"
+    "sinon": "9.2.4"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
- fix: use newDate() instead of _scanAt and find undefined lockedAt
as otherwise, we won't pick up locked jobs ever
- fix: remove sorting from JOB_RETURN_QUERY to make the query efficient.
